### PR TITLE
1 게시물 목록과 projection 541p

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle
 build/
+test/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/src/test/java/com/zerook/b01/repository/BoardRepositoryTests.java
+++ b/src/test/java/com/zerook/b01/repository/BoardRepositoryTests.java
@@ -1,6 +1,7 @@
 package com.zerook.b01.repository;
 
 import com.zerook.b01.domain.Board;
+import com.zerook.b01.dto.BoardListReplyCountDTO;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -127,6 +128,29 @@ public class BoardRepositoryTests {
         Pageable pageable = PageRequest.of(1,10, Sort.by("bno").descending());
 
         Page<Board> result = boardRepository.searchAll(types, keyword, pageable);
+
+        log.info(result.getTotalPages());
+
+        log.info(result.getSize());
+
+        log.info(result.getNumber());
+
+        log.info(result.hasPrevious() + " : " + result.hasNext());
+
+        result.getContent().forEach(board -> log.info(board));
+
+    }
+
+    @Test
+    public void testSearchReplyCount() {
+
+        String[] types = {"t", "c", "w"};
+
+        String keyword = "101";
+
+        Pageable pageable = PageRequest.of(0,10, Sort.by("bno").descending());
+
+        Page<BoardListReplyCountDTO> result = boardRepository.searchWithReply(types, keyword, pageable);
 
         log.info(result.getTotalPages());
 


### PR DESCRIPTION
1. join
query.leftJoin(reply).on(reply.board.eq(board));

2. Projections.bean()
- JPQL의 결과를 바로 DTO로 처리하는 기능
- Board Entity의 속성과 Reply의 replyCount를 합쳐서 리스트에 보여줘야 할 때 Board Entity에 replyCount 속성을 추가하는게 아닌 Board Entity에서 필요한 속성과 replyCount 속성을 추가한 새로운 DTO를 생성하여 Projections.bean를 사용해 해당 DTO 객체로 만든다.